### PR TITLE
Fix: tyst redirect till login vid token-fel och ta bort debug-logg i Userboard

### DIFF
--- a/src/features/shared/utilities/fetchWithToken.ts
+++ b/src/features/shared/utilities/fetchWithToken.ts
@@ -29,21 +29,22 @@ export async function fetchWithToken<T>(input: RequestInfo | URL, options?: Requ
     headers: { Accept: 'application/json', ...(options?.headers || {}) },
   });
 
-  return fetchJson<T>(input, reqInit);
-    try {
-      // ...existing fetch logic...
-    } catch (error: any) {
-      // Om token-refresh misslyckas, logga ut och redirecta
-      const status = error?.status || error?.response?.status;
-      const message = typeof error?.message === 'string' ? error.message.toLowerCase() : '';
-      if (
-        status === 401 ||
-        status === 403 ||
-        message.includes('token')
-      ) {
-            clearTokens(); // Rensa tokens
-        window.location.href = '/login'; // Redirect till login
-      }
-      throw error;
+  try {
+    return await fetchJson<T>(input, reqInit);
+  } catch (error: any) {
+    // Om token-refresh misslyckas, logga ut och redirecta
+    const status = error?.status || error?.response?.status;
+    const message = typeof error?.message === 'string' ? error.message.toLowerCase() : '';
+    if (
+      status === 401 ||
+      status === 403 ||
+      message.includes('token')
+    ) {
+      clearTokens(); // Rensa tokens
+      window.location.href = '/login'; // Redirect till login
+      // Returnera ett "hängande" promise så att inget fel kastas vidare
+      return new Promise(() => {});
     }
+    throw error;
+  }
 }

--- a/src/features/usersboard/component/Userboard.tsx
+++ b/src/features/usersboard/component/Userboard.tsx
@@ -34,7 +34,7 @@ export default function Userboard() {
         {teachers.length > 0 && [
           <li className="lmslist-section-header" key="section-header-teachers">Lärare</li>,
           ...teachers.map((user, idx) => (
-            <li key={user.id ?? `teacher-${idx}`}>
+            <li key={user.id ? `teacher-${user.id}` : `teacher-${idx}`}>
               <div className="lmslist-info">
                 <span className="lmslist-name">{user.userName}</span>
                 <span className="lmslist-email">{user.email}</span>
@@ -47,7 +47,7 @@ export default function Userboard() {
         {students.length > 0 && [
           <li className="lmslist-section-header" key="section-header-students">Studenter</li>,
           ...students.map((user, idx) => (
-            <li key={user.id ?? `student-${idx}`}>
+            <li key={user.id ? `student-${user.id}` : `student-${idx}`}>
               <div className="lmslist-info">
                 <span className="lmslist-name">{user.userName}</span>
                 <span className="lmslist-email">{user.email}</span>

--- a/src/features/usersboard/component/Userboard.tsx
+++ b/src/features/usersboard/component/Userboard.tsx
@@ -14,7 +14,7 @@ export default function Userboard() {
   useEffect(() => {
     fetchWithToken<IUserDto[]>('https://localhost:7213/api/course/participants/my')
       .then((data) => {
-        setClassmates(data);
+        setClassmates(data || []);
       })
       .catch((err: any) => setError(err?.message || 'Något gick fel'))
       .finally(() => setLoading(false));

--- a/src/features/usersboard/component/Userboard.tsx
+++ b/src/features/usersboard/component/Userboard.tsx
@@ -14,7 +14,6 @@ export default function Userboard() {
   useEffect(() => {
     fetchWithToken<IUserDto[]>('https://localhost:7213/api/course/participants/my')
       .then((data) => {
-        console.log('API /api/course/participants/my response:', data);
         setClassmates(data);
       })
       .catch((err: any) => setError(err?.message || 'Något gick fel'))


### PR DESCRIPTION
- Tar bort console.log från Userboard.tsx (rensar debug-loggning av deltagare)
- Förbättrar fetchWithToken så att användaren alltid redirectas tyst till /login vid token-fel (ingen error stacktrace eller felruta syns)
- Fixar därmed React-varningen om unika keys och förbättrar användarupplevelsen vid utloggning/token-expiry