### PR TITLE
UserName sätts till e-post vid användarskapande via Userboard

### DIFF
--- a/src/features/usersboard/component/Userboard.tsx
+++ b/src/features/usersboard/component/Userboard.tsx
@@ -71,10 +71,7 @@ export default function Userboard() {
         body: JSON.stringify({
           Email: newUser.email,
           Password: newUser.password,
-          UserName: `${newUser.firstName}.${newUser.lastName}`.replace(
-            /\s+/g,
-            ""
-          ),
+          UserName: newUser.email,
           Role: newUser.role,
           CourseId: courseId,
         }),


### PR DESCRIPTION
Nu sätts UserName till e-postadressen när en ny användare skapas via Userboard. Inloggning sker med e-post som användarnamn. Fixar problem med inloggning för nyskapade användare.